### PR TITLE
Prevent merging PRs labeled `do not merge`

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,21 @@
+# Workflow found at https://twitter.com/benasher44/status/1503460237331734528
+# via https://www.jessesquires.com/blog/2021/08/24/useful-label-based-github-actions-workflows/
+# Credits to Ben Asher (https://benasher.co)
+
+name: Do not merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'do not merge') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'do not merge'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
This allows us to use the `do not merge` label, which can be removed when a pull request is ready.
