### PR TITLE
VS Code: remove obsolete workarounds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,14 +34,13 @@
       "url": "/share/events.kha.schema.json"
     }
   ],
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.linting.enabled": true,
   "python.linting.pylintArgs": [
     "--enable-all-extensions"
   ],
   "python.linting.pylintCategorySeverity.refactor": "Warning",
   "python.linting.pylintEnabled": true,
-  "python.linting.pylintPath": "./.venv/bin/pylint",
+  "python.linting.pylintPath": "pylint",
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
Remove workarounds which no longer work with current versions of
VS Code’s Python extension (starting with version 2022.18.1).

From that version on, those workarounds are no longer necessary
anyway. The Python extension now appears to detect the venv’s
interpreter automatically and then switch to it.
